### PR TITLE
Fixes small Markdown rendering issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 <div align="center"><h1>Eurydice</h1></div>
 
 <div align="center">
+
 Eurydice (<b>E</b>metteur <b>U</b>nidirectionnel <b>R</b>edondant de <b>Y</b>ottabit pour le <b>D</b>ialogue <b>I</b>ntergiciel avec <b>C</b>orrection d'<b>E</b>rreur) provides an interface to transfer files through a physical diode using the [Lidi](https://github.com/ANSSI-FR/lidi/) utility.
+
 </div>
 
 ## 📁 Project structure


### PR DESCRIPTION
Fixes a small Markdown rendering issue because of HTML tags near one line containing Markdown syntax without blank lines which is then escaped from being parsed and rendered.